### PR TITLE
EDU-2131: Add LICENSE file for project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## What was changed
I propose that the application be released under the MIT license in order to encourage extensive use of the code we provide. This PR adds that license, assigning copyright to Temporal Technologies Inc. 

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes EDU-2131

2. How was this tested:
N/A 

3. Any docs updates needed?
No
