### PR TITLE
Fix off-by-one error in fulfillment code

### DIFF
--- a/order/activities.go
+++ b/order/activities.go
@@ -26,6 +26,10 @@ type FulfillOrderResult struct {
 }
 
 func (a *Activities) FulfillOrder(ctx context.Context, input FulfillOrderInput) (FulfillOrderResult, error) {
+	if len(input.Items) < 1 {
+		return FulfillOrderResult{}, nil
+	}
+
 	var fulfillments []Fulfillment
 
 	// Hard coded. Open discussion where this stub boundary should live.
@@ -45,7 +49,7 @@ func (a *Activities) FulfillOrder(ctx context.Context, input FulfillOrderInput) 
 			fulfillments,
 			Fulfillment{
 				Location: "Warehouse B",
-				Items:    input.Items[1 : len(input.Items)],
+				Items:    input.Items[1:len(input.Items)],
 			},
 		)
 	}

--- a/order/activities_test.go
+++ b/order/activities_test.go
@@ -8,6 +8,29 @@ import (
 	"go.temporal.io/sdk/testsuite"
 )
 
+func TestFulfillOrderZeroItems(t *testing.T) {
+	testSuite := testsuite.WorkflowTestSuite{}
+
+	var a *order.Activities
+
+	env := testSuite.NewTestActivityEnvironment()
+	env.RegisterActivity(a.FulfillOrder)
+
+	input := order.FulfillOrderInput{
+		Items: []order.Item{},
+	}
+
+	future, err := env.ExecuteActivity(a.FulfillOrder, input)
+	require.NoError(t, err)
+
+	var result order.FulfillOrderResult
+	require.NoError(t, future.Get(&result))
+
+	expected := order.FulfillOrderResult{}
+
+	require.Equal(t, expected, result)
+}
+
 func TestFulfillOrderOneItem(t *testing.T) {
 	testSuite := testsuite.WorkflowTestSuite{}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
This fixes an off-by-one error (selection of an array slice omits the final element) in the Activity that creates a fulfillment. 

## Why?
When submitting an order for two items, I found that there were two fulfillments, as expected. However, I also found that the second one was empty. 

## Checklist
<!--- add/delete as needed --->

1. Closes: N/A

2. How was this tested:
I tested this manually, observing that the second fulfillment was empty (before the change) and that it contained the expected content (after the change). I hope to create an automated test to validate the desired behavior, but wanted to submit a draft PR with the fix first.

3. Any docs updates needed?
No
