### PR TITLE
changed Registered to Booked, for clarity

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,8 +9,8 @@ sequenceDiagram
     
     Customer->>Order: place order
     Order->>Shipment: create shipment
-    Shipment->>Courier: register shipment
-    Courier->>Shipment: shipment registered
+    Shipment->>Courier: book shipment
+    Courier->>Shipment: shipment booked
     Shipment->>Customer: shipment created
     Courier->>Shipment: shipment dispatched
     Shipment->>Customer: shipment dispatched

--- a/shipment/activities.go
+++ b/shipment/activities.go
@@ -14,22 +14,22 @@ type Activities struct {
 
 var a Activities
 
-// RegisterShipmentInput is the input for the RegisterShipment operation.
+// BookShipmentInput is the input for the BookShipment operation.
 // All fields are required.
-type RegisterShipmentInput struct {
+type BookShipmentInput struct {
 	OrderID string
 	Items   []Item
 }
 
-// RegisterShipmentResult is the result for the RegisterShipment operation.
+// BookShipmentResult is the result for the BookShipment operation.
 // CourierReference is recorded where available, to allow tracking enquiries.
-type RegisterShipmentResult struct {
+type BookShipmentResult struct {
 	CourierReference string
 }
 
-// RegisterShipment registers a shipment with a courier.
-func (a *Activities) RegisterShipment(ctx context.Context, input RegisterShipmentInput) (RegisterShipmentResult, error) {
-	return RegisterShipmentResult{}, nil
+// BookShipment engages a courier who can deliver the shipment to the customer
+func (a *Activities) BookShipment(ctx context.Context, input BookShipmentInput) (BookShipmentResult, error) {
+	return BookShipmentResult{}, nil
 }
 
 const from = "orders@reference-app.example"

--- a/shipment/shipment.go
+++ b/shipment/shipment.go
@@ -27,15 +27,15 @@ const ShipmentUpdateSignalName = "ShipmentUpdate"
 type ShipmentStatus int
 
 const (
-	// ShipmentStatusRegistered represents a shipment which has been registered but not dispatched.
-	ShipmentStatusRegistered ShipmentStatus = iota
-	// ShipmentStatusDispatched represents a shipment which has been dispatched but not delivered.
+	// Represents a shipment acknowledged by a courier, but not yet picked up
+	ShipmentStatusBooked ShipmentStatus = iota
+	// Represents a shipment picked up by a courier, but not yet delivered to the customer
 	ShipmentStatusDispatched
-	// ShipmentStatusDelivered represents a shipment which has been delivered.
+	// Represents a shipment that has been delivered to the customer
 	ShipmentStatusDelivered
 )
 
-// ShipmentUpdateSignal is used by couriers to update a shipment's status.
+// ShipmentUpdateSignal is used by a courier to update a shipment's status.
 type ShipmentUpdateSignal struct {
 	Status ShipmentStatus
 }
@@ -66,8 +66,8 @@ func (s *shipmentImpl) run(ctx workflow.Context, input ShipmentInput) (ShipmentR
 	)
 
 	err := workflow.ExecuteActivity(ctx,
-		a.RegisterShipment,
-		RegisterShipmentInput{
+		a.BookShipment,
+		BookShipmentInput{
 			OrderID: input.OrderID,
 			Items:   input.Items,
 		},

--- a/shipment/shipment_test.go
+++ b/shipment/shipment_test.go
@@ -25,7 +25,7 @@ func TestShipmentWorkflow(t *testing.T) {
 		},
 	}
 
-	env.RegisterActivity(a.RegisterShipment)
+	env.RegisterActivity(a.BookShipment)
 
 	env.OnActivity(a.ShipmentCreatedNotification, mock.Anything, mock.Anything).Return(
 		func(ctx context.Context, input shipment.ShipmentCreatedNotificationInput) error {


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
I changed the value of the initial shipment status from "Registered" to "Booked" to more clearly convey its meaning (i.e., that the seller has engaged a courier to deliver the shipment). I also renamed the related Activity and data structures, as well as updated the corresponding sequence diagram to reflect this.

## Why?
The meaning of "Registered" was not clear. We debated several other terms, including created, prepared, accepted, awaiting, posted, and scheduled. Each of those also had disadvantages (for example, "accepted" might be confused for the customer having accepted delivery of the shipment instead of the courier accepting the obligation to deliver it). 

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
I ran `go test` after in the `order` and `shipment` directories after making the change. All tests ran successfully. I also did a recursive grep of the Go source code and found that all references to the original status value had now been updated.

3. Any docs updates needed?
I updated the sequence diagram in the `docs` directory to reflect this change.
