### PR TITLE
changed format of Workflow ID for shipments

### DIFF
--- a/order/workflows.go
+++ b/order/workflows.go
@@ -93,5 +93,5 @@ func (o *orderImpl) processShipments(ctx workflow.Context, fulfillments []Fulfil
 
 // ShipmentWorkflowID creates a shipment workflow ID from an order ID.
 func ShipmentWorkflowID(orderID string, fulfillmentID int) string {
-	return fmt.Sprintf("shipment:%s:%d", orderID, fulfillmentID)
+	return fmt.Sprintf("shipment:%d-order:%s", fulfillmentID, orderID)
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I changed the format of the Workflow ID used for shipments to make the order ID more recognizable and to more clearly convey the many-to-one relationship between shipments and orders. 

This shows the format before the change:
![The "before" screenshot](https://github.com/temporalio/orders-reference-app-go/assets/2183904/06ad028a-7b1f-4a56-ae6b-c0e6203fe8aa)

This shows the format after the change:
![The "after" screenshot](https://github.com/temporalio/orders-reference-app-go/assets/2183904/b8c9f8e3-2960-44f3-b252-95f2996ef783)


## Why?
I changed the format temporarily while investigating a problem with the processing of concurrent orders. Although I discovered that the code worked correctly and the problem was in the JSON file I was using as input, I found the new Workflow IDs for shipments was a bit more clear and decided to submit this PR to see if others agreed.


## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
I ran the Order Workflow before and after the change.

3. Any docs updates needed?
No
