### PR TITLE
Updated to use the same TaskQueue as Worker

### DIFF
--- a/web/src/routes/api/order/+server.ts
+++ b/web/src/routes/api/order/+server.ts
@@ -9,7 +9,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			{
 				method: 'POST',
 				body: JSON.stringify({
-					taskQueue: { name: 'order' },
+					taskQueue: { name: 'orders' },
 					workflowType: { name: 'Order' },
 					input: [order]
 				})


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I changed the name of the Task Queue from `order` to `orders`

## Why?
<!-- Tell your future self why have you made these changes -->
This is necessary because of some refactoring that Rob recently did, [changing the name of the Task Queue](https://github.com/temporalio/orders-reference-app-go/blob/main/app/order/workflows.go#L12) in the order Worker from singular to plural. Without a corresponding change to the Web UI, the application will submit a Workflow Execution request to a different Task Queue from the one to which the Worker polls.


## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
I tested it locally by running the Web UI before and after the change.

3. Any docs updates needed?
No
