### PR TITLE
updated the code to make Order #1 always contain a single item

### DIFF
--- a/web/src/lib/types/order.ts
+++ b/web/src/lib/types/order.ts
@@ -68,6 +68,18 @@ export const generateOrders = (quantity: number): Order[] => {
 			items: selected.map((item) => ({ ...item, quantity: Math.floor(Math.random() * 3) + 1 }))
 		});
 	}
+	// For demo purposes, we'll ensure that the first order always 
+	// contains a single specific item (whose SKU does not trigger 
+	// item unavailability). This will make it easy to demonstrate
+	// the simplest possible case.
+	const sortedItems = items.sort(function(a, b) {
+		return (a.sku < b.sku) ? -1 : (a.sku > b.sku) ? 1 : 0;
+	});
+	orders[0].items = [{
+		sku: sortedItems[sortedItems.length - 1].sku,
+		description: items[sortedItems.length - 1].description,
+		quantity: 1
+	}];
 	return orders;
 };
 


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I updated the page that provides a list of orders from which to submit. This change ensures that Order #1 can consistently be used to demonstrate the simplest possible case, one where there is a single in-stock item which is fulfilled in one shipment. 

## Why?
<!-- Tell your future self why have you made these changes -->
The list of orders is randomly generated, making it difficult (and in some cases, impossible) to find one that demonstrates the simplest possible case. 

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
I manually tested it by continually refreshing the page and confirming that order #1 always contained a single item with the SKU I expected (the last one when sorted alphabetically, which is Vans based on the current dataset). That SKU does not trigger the "item not available" user interaction.

3. Any docs updates needed?
No