### PR TITLE
Removes the Docker Compose file for Mailpit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-name: orders-reference-app
-
-services:
-  mailpit:
-    image: axllent/mailpit
-    ports:
-      - "1025:1025"
-      - "8025:8025"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
I removed the Docker Compose file for Mailpit

## Why?
<!-- Tell your future self why have you made these changes -->
It appears that the application no longer uses SMTP for notifications, so there is no longer a reason to run Mailpit. I believe that the presence of this file could lead a user to conclude that Docker is required to run TORA, possibly discouraging them from exploring further and finding out that this isn't the case.
