### PR TITLE
Add Kubernetes manifests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ FROM scratch AS oms-worker
 
 COPY --from=oms-builder /usr/local/bin/oms /usr/local/bin/oms
 
-ENTRYPOINT ["/usr/local/bin/oms"]
-CMD ["worker"]
+ENTRYPOINT ["/usr/local/bin/oms", "worker"]
 
 FROM scratch as oms-api
 
@@ -27,11 +26,12 @@ EXPOSE 8081
 EXPOSE 8082
 EXPOSE 8083
 EXPOSE 8084
+VOLUME /data
+ENV DATA_DIR=/data
 
 COPY --from=oms-builder /usr/local/bin/oms /usr/local/bin/oms
 
-ENTRYPOINT ["/usr/local/bin/oms"]
-CMD ["api"]
+ENTRYPOINT ["/usr/local/bin/oms", "api"]
 
 FROM scratch as oms-codec-server
 
@@ -39,5 +39,4 @@ EXPOSE 8089
 
 COPY --from=oms-builder /usr/local/bin/oms /usr/local/bin/oms
 
-ENTRYPOINT ["/usr/local/bin/oms"]
-CMD ["codec-server"]
+ENTRYPOINT ["/usr/local/bin/oms", "codec-server"]

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -8,6 +8,7 @@ import (
 // AppConfig is a struct that holds the configuration for the Order/Shipment/Fraud/Billing system.
 type AppConfig struct {
 	BindOnIP     string
+	DataDir      string
 	BillingPort  int32
 	BillingURL   string
 	OrderPort    int32
@@ -22,6 +23,7 @@ type AppConfig struct {
 func AppConfigFromEnv() (AppConfig, error) {
 	conf := AppConfig{
 		BindOnIP:     "127.0.0.1",
+		DataDir:      "./",
 		BillingPort:  8081,
 		BillingURL:   "http://127.0.0.1:8081",
 		OrderPort:    8082,
@@ -34,6 +36,10 @@ func AppConfigFromEnv() (AppConfig, error) {
 
 	if ip := os.Getenv("BIND_ON_IP"); ip != "" {
 		conf.BindOnIP = ip
+	}
+
+	if p := os.Getenv("DATA_DIR"); p != "" {
+		conf.DataDir = p
 	}
 
 	if p := os.Getenv("BILLING_API_URL"); p != "" {

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"path"
 	"slices"
 
 	"github.com/jmoiron/sqlx"
@@ -120,7 +121,8 @@ func RunAPIServers(ctx context.Context, config config.AppConfig, client client.C
 	var err error
 
 	if slices.Contains(services, "orders") || slices.Contains(services, "shipment") {
-		db, err = sqlx.Connect("sqlite", "./api-store.db")
+		dbPath := path.Join(config.DataDir, "api-store.db")
+		db, err = sqlx.Connect("sqlite", dbPath)
 		db.SetMaxOpenConns(1) // SQLite does not support concurrent writes
 		if err != nil {
 			return fmt.Errorf("failed to open database: %w", err)

--- a/deployments/create-k8s.sh
+++ b/deployments/create-k8s.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+rm -rf ./k8s
+mkdir -p ./k8s
+
+# Remove restart policy from all services
+# Set controller type to statefulset for apis, which maintain a cache on disk
+# Set service type to loadbalancer for web service, which should be exposed outside the cluster
+yq \
+    '(del(.services[].restart)) |
+     ((.services | (.billing-api, .main-api)).labels += {"kompose.controller.type":"statefulset"}) |
+     (.services.web.labels += {"kompose.service.type":"loadbalancer"})
+     ' \
+    docker-compose-split.yaml | \
+    kompose -f - -o k8s convert -n oms --with-kompose-annotation=false
+
+# Rename the web-tcp service to web
+mv ./k8s/web-tcp-service.yaml ./k8s/web-service.yaml
+yq '(.metadata.name, .metadata.labels.["io.kompose.service"]) |= "web"' -i ./k8s/web-service.yaml
+
+# Use standard kubernetes labels
+for f in ./k8s/*.yaml; do
+    yq -i \
+    '((.. | select(has("io.kompose.service")).["io.kompose.service"] | key) = "app.kubernetes.io/component") |
+     ((.. | select(has("app.kubernetes.io/component"))) += {"app.kubernetes.io/name":"oms"})
+    ' $f
+done
+
+# Correct images
+for f in ./k8s/*-worker-deployment.yaml; do
+    yq -i '.spec.template.spec.containers[0].image |= "ghcr.io/temporalio/reference-app-orders-go-worker:latest" |
+           .spec.template.spec.containers[0].imagePullPolicy = "Always"' $f
+done
+for f in ./k8s/*-api-statefulset.yaml; do
+    yq -i '.spec.template.spec.containers[0].image |= "ghcr.io/temporalio/reference-app-orders-go-api:latest" |
+           .spec.template.spec.containers[0].imagePullPolicy = "Always"' $f
+done
+yq -i '.spec.template.spec.containers[0].image |= "ghcr.io/temporalio/reference-app-orders-go-codec-server:latest" |
+       .spec.template.spec.containers[0].imagePullPolicy = "Always"' k8s/codec-server-deployment.yaml
+
+# Disable service links
+for f in ./k8s/*-{deployment,statefulset}.yaml; do
+    yq -i '.spec.template.spec.enableServiceLinks = false' $f
+done
+
+# Remove redundant defaults
+for f in ./k8s/*.yaml; do
+    yq -i 'del(.spec.template.spec.restartPolicy)' $f
+done
+
+# Update Temporal Address
+for f in ./k8s/*-{statefulset,deployment}.yaml; do
+    yq -i '(.spec.template.spec.containers[0].env[] | select(.name == "TEMPORAL_ADDRESS").value) |= "temporal-frontend.temporal:7233"' $f
+done

--- a/deployments/docker-compose-split.yaml
+++ b/deployments/docker-compose-split.yaml
@@ -6,7 +6,7 @@ services:
     environment:
       - TEMPORAL_ADDRESS=host.docker.internal:7233
       - FRAUD_API_URL=http://billing-api:8084
-    command: ["worker", "-k", "supersecretkey", "-s", "billing"]
+    command: ["-k", "supersecretkey", "-s", "billing"]
     restart: on-failure
   billing-api:
     build:
@@ -17,7 +17,7 @@ services:
       - BIND_ON_IP=0.0.0.0
       - BILLING_API_PORT=8081
       - FRAUD_API_PORT=8084
-    command: ["api", "-k", "supersecretkey", "-s", "billing,fraudcheck"]
+    command: ["-k", "supersecretkey", "-s", "billing,fraudcheck"]
     ports:
       - "8081:8081"
       - "8084:8084"
@@ -31,7 +31,7 @@ services:
       - BILLING_API_URL=http://billing-api:8081
       - ORDER_API_URL=http://main-api:8082
       - SHIPMENT_API_URL=http://main-api:8083
-    command: ["worker", "-k", "supersecretkey", "-s", "order,shipment"]
+    command: ["-k", "supersecretkey", "-s", "order,shipment"]
     restart: on-failure
   main-api:
     build:
@@ -42,17 +42,19 @@ services:
       - BIND_ON_IP=0.0.0.0
       - ORDER_API_PORT=8082
       - SHIPMENT_API_PORT=8083
-    command: ["api", "-k", "supersecretkey", "-s", "order,shipment"]
+    command: ["-k", "supersecretkey", "-s", "order,shipment"]
     ports:
       - "8082:8082"
       - "8083:8083"
+    volumes:
+      - main-api-data:/data
     restart: on-failure
   codec-server:
     build:
       context: ../
       target: oms-codec-server
     # Adjust the web server URL to point to your Temporal Web instance.
-    command: ["codec-server", "-p", "8089", "-u", "http://localhost:8080"]
+    command: ["-p", "8089", "-u", "http://localhost:8080"]
     # If you are using a Temporal CLI's start-dev you can use this:
     # command: ["codec-server", "-p", "8089", "-u", "http://localhost:8233"]
     ports:
@@ -71,3 +73,5 @@ services:
     ports:
       - "3000:3000"
     restart: on-failure
+volumes:
+  main-api-data:

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - ORDER_API_URL=http://api:8082
       - SHIPMENT_API_URL=http://api:8083
       - FRAUD_API_URL=http://api:8084
-    command: ["worker", "-k", "supersecretkey"]
+    command: ["-k", "supersecretkey"]
     restart: on-failure
   api:
     build:
@@ -22,14 +22,16 @@ services:
       - ORDER_API_PORT=8082
       - SHIPMENT_API_PORT=8083
       - FRAUD_API_PORT=8084
-    command: ["api", "-k", "supersecretkey"]
+    command: ["-k", "supersecretkey"]
+    volumes:
+      - api-data:/data
     restart: on-failure
   codec-server:
     build:
       context: ../
       target: oms-codec-server
     # Adjust the web server URL to point to your Temporal Web instance.
-    command: ["codec-server", "-p", "8089", "-u", "http://localhost:8080"]
+    command: ["-p", "8089", "-u", "http://localhost:8080"]
     # If you are using a Temporal CLI's start-dev you can use this:
     # command: ["codec-server", "-p", "8089", "-u", "http://localhost:8233"]
     ports:
@@ -48,3 +50,5 @@ services:
     ports:
       - "3000:3000"
     restart: on-failure
+volumes:
+  api-data:

--- a/deployments/k8s/billing-api-service.yaml
+++ b/deployments/k8s/billing-api-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: billing-api
+    app.kubernetes.io/name: oms
+  name: billing-api
+  namespace: oms
+spec:
+  ports:
+    - name: "8081"
+      port: 8081
+      targetPort: 8081
+    - name: "8084"
+      port: 8084
+      targetPort: 8084
+  selector:
+    app.kubernetes.io/component: billing-api
+    app.kubernetes.io/name: oms

--- a/deployments/k8s/billing-api-statefulset.yaml
+++ b/deployments/k8s/billing-api-statefulset.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: billing-api
+    app.kubernetes.io/name: oms
+  name: billing-api
+  namespace: oms
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: billing-api
+      app.kubernetes.io/name: oms
+  serviceName: billing-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: billing-api
+        app.kubernetes.io/name: oms
+    spec:
+      containers:
+        - args:
+            - -k
+            - supersecretkey
+            - -s
+            - billing,fraudcheck
+          env:
+            - name: BILLING_API_PORT
+              value: "8081"
+            - name: BIND_ON_IP
+              value: 0.0.0.0
+            - name: FRAUD_API_PORT
+              value: "8084"
+            - name: TEMPORAL_ADDRESS
+              value: temporal-frontend.temporal:7233
+          image: reference-app-orders-go-api:latest
+          name: billing-api
+          ports:
+            - containerPort: 8081
+              protocol: TCP
+            - containerPort: 8084
+              protocol: TCP
+          imagePullPolicy: Never
+      enableServiceLinks: false

--- a/deployments/k8s/billing-worker-deployment.yaml
+++ b/deployments/k8s/billing-worker-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: billing-worker
+    app.kubernetes.io/name: oms
+  name: billing-worker
+  namespace: oms
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: billing-worker
+      app.kubernetes.io/name: oms
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: billing-worker
+        app.kubernetes.io/name: oms
+    spec:
+      containers:
+        - args:
+            - -k
+            - supersecretkey
+            - -s
+            - billing
+          env:
+            - name: FRAUD_API_URL
+              value: http://billing-api:8084
+            - name: TEMPORAL_ADDRESS
+              value: temporal-frontend.temporal:7233
+          image: reference-app-orders-go-worker:latest
+          name: billing-worker
+          imagePullPolicy: Never
+      enableServiceLinks: false

--- a/deployments/k8s/codec-server-deployment.yaml
+++ b/deployments/k8s/codec-server-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: codec-server
+    app.kubernetes.io/name: oms
+  name: codec-server
+  namespace: oms
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: codec-server
+      app.kubernetes.io/name: oms
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: codec-server
+        app.kubernetes.io/name: oms
+    spec:
+      containers:
+        - args:
+            - -p
+            - "8089"
+            - -u
+            - http://localhost:8080
+          image: reference-app-orders-go-codec-server:latest
+          name: codec-server
+          ports:
+            - containerPort: 8089
+              protocol: TCP
+          imagePullPolicy: Never
+          env: []
+      enableServiceLinks: false

--- a/deployments/k8s/codec-server-service.yaml
+++ b/deployments/k8s/codec-server-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: codec-server
+    app.kubernetes.io/name: oms
+  name: codec-server
+  namespace: oms
+spec:
+  ports:
+    - name: "8089"
+      port: 8089
+      targetPort: 8089
+  selector:
+    app.kubernetes.io/component: codec-server
+    app.kubernetes.io/name: oms

--- a/deployments/k8s/main-api-data-persistentvolumeclaim.yaml
+++ b/deployments/k8s/main-api-data-persistentvolumeclaim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/component: main-api-data
+    app.kubernetes.io/name: oms
+  name: main-api-data
+  namespace: oms
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/deployments/k8s/main-api-service.yaml
+++ b/deployments/k8s/main-api-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: main-api
+    app.kubernetes.io/name: oms
+  name: main-api
+  namespace: oms
+spec:
+  ports:
+    - name: "8082"
+      port: 8082
+      targetPort: 8082
+    - name: "8083"
+      port: 8083
+      targetPort: 8083
+  selector:
+    app.kubernetes.io/component: main-api
+    app.kubernetes.io/name: oms

--- a/deployments/k8s/main-api-statefulset.yaml
+++ b/deployments/k8s/main-api-statefulset.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: main-api
+    app.kubernetes.io/name: oms
+  name: main-api
+  namespace: oms
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: main-api
+      app.kubernetes.io/name: oms
+  serviceName: main-api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: main-api
+        app.kubernetes.io/name: oms
+    spec:
+      containers:
+        - args:
+            - -k
+            - supersecretkey
+            - -s
+            - order,shipment
+          env:
+            - name: BIND_ON_IP
+              value: 0.0.0.0
+            - name: ORDER_API_PORT
+              value: "8082"
+            - name: SHIPMENT_API_PORT
+              value: "8083"
+            - name: TEMPORAL_ADDRESS
+              value: temporal-frontend.temporal:7233
+          image: reference-app-orders-go-api:latest
+          name: main-api
+          ports:
+            - containerPort: 8082
+              protocol: TCP
+            - containerPort: 8083
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data
+              name: main-api-data
+          imagePullPolicy: Never
+      volumes:
+        - name: main-api-data
+          persistentVolumeClaim:
+            claimName: main-api-data
+      enableServiceLinks: false
+  volumeClaimTemplates:
+    - metadata:
+        labels:
+          app.kubernetes.io/component: main-api-data
+          app.kubernetes.io/name: oms
+        name: main-api-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 100Mi

--- a/deployments/k8s/main-worker-deployment.yaml
+++ b/deployments/k8s/main-worker-deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: main-worker
+    app.kubernetes.io/name: oms
+  name: main-worker
+  namespace: oms
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: main-worker
+      app.kubernetes.io/name: oms
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: main-worker
+        app.kubernetes.io/name: oms
+    spec:
+      containers:
+        - args:
+            - -k
+            - supersecretkey
+            - -s
+            - order,shipment
+          env:
+            - name: BILLING_API_URL
+              value: http://billing-api:8081
+            - name: ORDER_API_URL
+              value: http://main-api:8082
+            - name: SHIPMENT_API_URL
+              value: http://main-api:8083
+            - name: TEMPORAL_ADDRESS
+              value: temporal-frontend.temporal:7233
+          image: reference-app-orders-go-worker:latest
+          name: main-worker
+          imagePullPolicy: Never
+      enableServiceLinks: false

--- a/deployments/k8s/oms-namespace.yaml
+++ b/deployments/k8s/oms-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oms
+  namespace: oms

--- a/deployments/k8s/web-deployment.yaml
+++ b/deployments/k8s/web-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: web
+    app.kubernetes.io/name: oms
+  name: web
+  namespace: oms
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: web
+      app.kubernetes.io/name: oms
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: web
+        app.kubernetes.io/name: oms
+    spec:
+      containers:
+        - env:
+            - name: BILLING_API_URL
+              value: http://billing-api:8081
+            - name: FRAUD_API_URL
+              value: http://billing-api:8084
+            - name: ORDER_API_URL
+              value: http://main-api:8082
+            - name: ORIGIN
+              value: http://localhost:3000
+            - name: SHIPMENT_API_URL
+              value: http://main-api:8083
+          image: ghcr.io/temporalio/reference-app-orders-web:latest
+          name: web
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+      enableServiceLinks: false

--- a/deployments/k8s/web-service.yaml
+++ b/deployments/k8s/web-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: web
+    app.kubernetes.io/name: oms
+  name: web
+  namespace: oms
+spec:
+  ports:
+    - name: "3000"
+      port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/component: web
+    app.kubernetes.io/name: oms
+  type: LoadBalancer


### PR DESCRIPTION
Include the script used to generate the initial versions for reference.

docker compose and k8s deployments now use volumes so that the API cache database will persist between deploys etc
