### PR TITLE
Ignore transient artifact created via `go build ./cmd/oms`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.so
 *.dylib
 
+# Executable created by running `go build ./cmd/oms` on macOS or Linux
+/oms
+
 # Test binary, built with `go test -c`
 *.test
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

I updated the `.gitignore` file to add an entry for a file named `oms` at the project root. 

## Why?
<!-- Tell your future self why have you made these changes -->

The application executable built with `go build ./cmd/oms` on Windows will, I assume, have a `.exe` file extension, which would be ignored based on the current `.gitignore` file. If you run that command on macOS or Linux, it will produce an executable with no such extension, so it wouldn't be ignored. This change prevents that executable from being inadvertently added to revision control.