### PR TITLE
Disable UI in functional test

### DIFF
--- a/app/test/order_test.go
+++ b/app/test/order_test.go
@@ -75,7 +75,7 @@ func Test_Order(t *testing.T) {
 
 	s, err := testsuite.StartDevServer(ctx, testsuite.DevServerOptions{
 		ClientOptions: &client.Options{},
-		EnableUI:      true,
+		EnableUI:      false,
 		ExtraArgs:     []string{"--dynamic-config-value", "system.forceSearchAttributesCacheRefreshOnRead=true"},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

I disabled the UI when starting the DevServer in the functional test.

## Why?
<!-- Tell your future self why have you made these changes -->

When running the functional test through a GitHub action on Windows, I observed that the test failed due to an invalid (out of range) port number calculated for the UI server. That's a bug in the SDK (and [I filed a report on it](https://github.com/temporalio/sdk-go/issues/1526)), but Chad states that enabling the UI should not be necessary in this test. Consequently, I have disabled it, which should ensure that the test runs reliably while the SDK bug remains.

I tested this by running the functional test manually multiple times after making the change. It passed each time (although I probably need to run it 65,535 times to feel really confident).