### PR TITLE
Make it easier to demo maintenance mode.

### DIFF
--- a/app/billing/workflows.go
+++ b/app/billing/workflows.go
@@ -8,9 +8,10 @@ import (
 
 // Charge Workflow invoices and processes payment for a fulfillment.
 func Charge(ctx workflow.Context, input *ChargeInput) (*ChargeResult, error) {
+	logger := workflow.GetLogger(ctx)
 	ctx = workflow.WithActivityOptions(ctx,
 		workflow.ActivityOptions{
-			StartToCloseTimeout: 30 * time.Second,
+			ScheduleToCloseTimeout: 30 * time.Second,
 		},
 	)
 
@@ -40,7 +41,8 @@ func Charge(ctx workflow.Context, input *ChargeInput) (*ChargeResult, error) {
 		},
 	)
 	if err := cwf.Get(ctx, &charge); err != nil {
-		return nil, err
+		logger.Warn("Charge failed", "customer_id", input.CustomerID, "error", err)
+		charge.Success = false
 	}
 
 	return &ChargeResult{

--- a/app/fraud/api.go
+++ b/app/fraud/api.go
@@ -12,9 +12,10 @@ type FraudLimitInput struct {
 	Limit int32 `json:"limit"`
 }
 
-// FraudLimitResult is the result for the GetLimit API.
-type FraudLimitResult struct {
-	Limit int32 `json:"limit"`
+// FraudSettingsResult is the result for the GetSettings API.
+type FraudSettingsResult struct {
+	Limit           int32 `json:"limit"`
+	MaintenanceMode bool  `json:"maintenanceMode"`
 }
 
 // FraudCheckInput is the input for the check endpoint.
@@ -41,7 +42,7 @@ func Router(logger *slog.Logger) http.Handler {
 	r := http.NewServeMux()
 	h := handlers{customerChargeTally: make(map[string]int32), logger: logger}
 
-	r.HandleFunc("GET /limit", h.handleGetLimit)
+	r.HandleFunc("GET /settings", h.handleGetSettings)
 	r.HandleFunc("POST /limit", h.handleSetLimit)
 	r.HandleFunc("POST /maintenance", h.handleSetMaintenanceMode)
 	r.HandleFunc("POST /reset", h.handleReset)
@@ -50,10 +51,13 @@ func Router(logger *slog.Logger) http.Handler {
 	return r
 }
 
-func (h *handlers) handleGetLimit(w http.ResponseWriter, _ *http.Request) {
+func (h *handlers) handleGetSettings(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	err := json.NewEncoder(w).Encode(FraudLimitResult{Limit: h.limit})
+	err := json.NewEncoder(w).Encode(FraudSettingsResult{
+		Limit:           h.limit,
+		MaintenanceMode: h.maintenanceMode,
+	})
 	if err != nil {
 		h.logger.Error("Failed to encode limit result", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
       target: oms-worker
     environment:
       - TEMPORAL_ADDRESS=host.docker.internal:7233
+      - DEBUG=true
       - BILLING_API_URL=http://api:8081
       - ORDER_API_URL=http://api:8082
       - SHIPMENT_API_URL=http://api:8083
@@ -18,6 +19,7 @@ services:
     environment:
       - TEMPORAL_ADDRESS=host.docker.internal:7233
       - BIND_ON_IP=0.0.0.0
+      - DEBUG=true
       - BILLING_API_PORT=8081
       - ORDER_API_PORT=8082
       - SHIPMENT_API_PORT=8083


### PR DESCRIPTION
This causes payments to fail due to the fraud service returning 503 until the mode is reset.

This can be done via the UI, avoiding the need to mess on the terminal.
