### PR TITLE
Updated logic for spending limit 

### DIFF
--- a/app/fraud/api.go
+++ b/app/fraud/api.go
@@ -108,8 +108,10 @@ func (h *handlers) handleRunCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.tallyLock.Lock()
-	h.customerChargeTally[input.CustomerID] += input.Charge
-	declined := h.limit > 0 && h.customerChargeTally[input.CustomerID] > h.limit
+	declined := h.limit > 0 && input.Charge+h.customerChargeTally[input.CustomerID] > h.limit
+	if !declined {
+		h.customerChargeTally[input.CustomerID] += input.Charge
+	}
 	h.tallyLock.Unlock()
 	result := FraudCheckResult{Declined: declined}
 


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I changed the business logic related to calculating the per-customer tally. Previously, this cumulative total was updated regardless of whether the fraud check passed or failed. With this change, the tally is only updated when it passes. 

## Why?
<!-- Tell your future self why have you made these changes -->
Prior to this change, a call to the Fraud API's `/check` endpoint resulted in the per-customer tally being updated regardless of whether the charge was accepted or declined. Consequently, a customer who attempts to place a purchase that exceeds the limit would be declined for a subsequent purchase that is well below the limit. 

The updated logic considers both the tally and the current purchase price when determining whether to decline, but only updates the tally when the fraud check passes.