### PR TITLE
Mention/link to software required to run the OMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ repository to your machine and follow the steps below. Unless otherwise
 noted, you should execute the commands from the root directory of your 
 clone.
 
+### Required Software
+You will need [Go](https://go.dev/) to run the core OMS application, 
+the [Temporal CLI](https://docs.temporal.io/cli#install) to run the 
+Temporal Service locally, plus [Node.js](https://nodejs.org/) and 
+the [pnpm package manager](https://pnpm.io/) to run the OMS web 
+application. 
+
+
 ### Start the Temporal Service
 Run the following command in your terminal:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ clone.
 You will need [Go](https://go.dev/) to run the core OMS application, 
 the [Temporal CLI](https://docs.temporal.io/cli#install) to run the 
 Temporal Service locally, plus [Node.js](https://nodejs.org/) and 
-the [pnpm package manager](https://pnpm.io/) to run the OMS web 
+the [pnpm](https://pnpm.io/) package manager to run the OMS web 
 application. 
 
 

--- a/docs/run-local-cli-service.md
+++ b/docs/run-local-cli-service.md
@@ -5,6 +5,13 @@ Temporal Service provided by the `temporal server start-dev`
 command. This is an expanded version of the instructions found 
 in the _Quickstart_ section of the top-level README file.
 
+### Required Software
+You will need [Go](https://go.dev/) to run the core OMS application,
+the [Temporal CLI](https://docs.temporal.io/cli#install) to run the
+Temporal Service locally, plus [Node.js](https://nodejs.org/) and
+the [pnpm package manager](https://pnpm.io/) to run the OMS web
+application.
+
 
 ### Start the Temporal Service
 

--- a/docs/run-local-cli-service.md
+++ b/docs/run-local-cli-service.md
@@ -9,7 +9,7 @@ in the _Quickstart_ section of the top-level README file.
 You will need [Go](https://go.dev/) to run the core OMS application,
 the [Temporal CLI](https://docs.temporal.io/cli#install) to run the
 Temporal Service locally, plus [Node.js](https://nodejs.org/) and
-the [pnpm package manager](https://pnpm.io/) to run the OMS web
+the [pnpm](https://pnpm.io/) package manager to run the OMS web
 application.
 
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

I added a "Required Software" section to the top-level README and the instructions for running the application locally. This lists and links to the software that must be installed in order to run the OMS as described in those instructions. 

## Why?
<!-- Tell your future self why have you made these changes -->
Primarily, because I think backend developers may be unfamiliar with the `pnpm` package manager. I wanted to reduce friction during setup by letting them know where to find that. However, I think it's important to list all of the required tools. I opted not to list specific versions, since keeping that list updated as new versions of those tools are released requires maintenance effort. An incomplete list of versions can imply that one not shown there is known not to work.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
I set up the OMS on a clean installation of Windows 11 some time ago. I documented the tools I had to install in order to get everything running on that machine. That was a more thorough test that using my MBP, which already has a pretty extensive set of tools installed. 

