### PR TITLE
Add links to the YouTube videos, which are now public

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ repository to your machine and follow the steps below. Unless otherwise
 noted, you should execute the commands from the root directory of your 
 clone. 
 
-You can also see a demonstration of these steps in the _[Setting
-up and running the OMS_ video](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv&index=2), part of a [four-part video series](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv) that covers the OMS.
+You can also see a demonstration of these steps in the [Setting
+up and running the OMS video](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv&index=2), part of a [four-part video series](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv) that covers the OMS.
 
 ### Required Software
 You will need [Go](https://go.dev/) to run the core OMS application, 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ repository to your machine and follow the steps below. Unless otherwise
 noted, you should execute the commands from the root directory of your 
 clone. 
 
-You can also see a demonstration of these steps in the [Setting
-up and running the OMS video](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv&index=2), part of a [four-part video series](https://www.youtube.com/playlist?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv) that covers the OMS.
+You can also see a demonstration of these steps in the _[Setting
+up and running the OMS](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv&index=2)_ video, part of a [four-part video series](https://www.youtube.com/playlist?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv) that covers the OMS.
 
 ### Required Software
 You will need [Go](https://go.dev/) to run the core OMS application, 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ noted, you should execute the commands from the root directory of your
 clone. 
 
 You can also see a demonstration of these steps in the [Setting
-up and running the OMS video](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv&index=2), part of a [four-part video series](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv) that covers the OMS.
+up and running the OMS video](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv&index=2), part of a [four-part video series](https://www.youtube.com/playlist?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv) that covers the OMS.
 
 ### Required Software
 You will need [Go](https://go.dev/) to run the core OMS application, 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ running the application in various environments.
 If you'd like to jump right in and run the OMS locally, clone this 
 repository to your machine and follow the steps below. Unless otherwise 
 noted, you should execute the commands from the root directory of your 
-clone.
+clone. 
+
+You can also see a demonstration of these steps in the _[Setting
+up and running the OMS_ video](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv&index=2), part of a [four-part video series](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv) that covers the OMS.
 
 ### Required Software
 You will need [Go](https://go.dev/) to run the core OMS application, 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 The documentation for the Order Management System reference application 
 is organized into multiple sections. You may also be interested in 
-watching our [four-part video series](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv&index=2), which explains the OMS and demonstrates 
+watching our [four-part video series](https://www.youtube.com/playlist?list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv&index=2), which explains the OMS and demonstrates 
 several ways of running it. 
 
 ## Understanding the OMS

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,9 @@
 ![OMS logo](images/oms-logo.png)
 
 The documentation for the Order Management System reference application 
-is organized into multiple sections:
+is organized into multiple sections. You may also be interested in 
+watching our [four-part video series](https://www.youtube.com/watch?v=ltlC7kVdFEU&list=PLl9kRkvFJrlRNbBZYY9v1XaAjqb2oj8pv&index=2), which explains the OMS and demonstrates 
+several ways of running it. 
 
 ## Understanding the OMS
 * [Overview](overview.md): 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I created a four-part video series that briefly explains the OMS and then demonstrates how to run and use it in various scenarios. I have now made those videos public just ahead of the OMS demos at Replay. This PR adds links to those videos to the documentation.

## Why?
<!-- Tell your future self why have you made these changes -->
Although the steps for running and using the OMS are documented, some users may wish to see a demonstration. These videos provide that, along with some context about what the application does. 


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

EDU-3171

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I viewed both README files in my browser and verified that the links pointed to the intended destinations.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->

No