### PR TITLE
Changed to macos-13 since macos-12 is now deprecated

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
             # No need to upload coverage reports for multiple platforms
             uploadCoverage: true
           - os: macos-intel
-            runsOn: macos-12
+            runsOn: macos-13
           - os: macos-arm
             runsOn: macos-14
     runs-on: ${{ matrix.runsOn || matrix.os }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

I updated the `build-and-test.yml` GitHub workflow to use macos-13 instead of macos-12 for the intel platform.

## Why?
<!-- Tell your future self why have you made these changes -->
The macos-12 runner is [now deprecated](https://github.com/actions/runner-images?tab=readme-ov-file#available-images). Arguably we could drop support for the Intel-based Macs entirely, but there's probably more benefit to just updating it while Apple continues to support the platform.
