### PR TITLE
updated to describe the use of MongoDB in a k8s deployment

### DIFF
--- a/docs/deploy-on-k8s.md
+++ b/docs/deploy-on-k8s.md
@@ -90,27 +90,23 @@ mongo-0                           1/1     Running   0          24h
 You'll know that the application is up when the READY column shows
 "1/1" for every pod.
 
-Please note that, while in most regards the deployment is a standard 
-Kubernetes setup, there is one thing which is a little unusual. The 
-OMS application's API services make use of a cache to ensure that they 
-can quickly provide lists of all orders and shipments. This cache is
-implemented using a disk-based SQLite database, which makes these 
-API services stateful. If an API pod needs to be restarted (for example, 
-due to upgrade, node failure, etc.), then it must be brought back up 
-with the same disk as before to ensure it does not lose its cache. 
-For this reason, the API services use Statefulset instead of Deployment.
-The cache is mounted via a Kubernetes volume to ensure that the pod 
-will maintain its disk between runs.
+### Application cache
 
-As this cache uses the disk, which is not easily shared among pods, 
-this also means the API Statefulsets cannot be safely scaled. If there 
-were to be more than one `main-api` pod, for example, each pod would 
-see different order creations, and therefore have a different cache 
-of orders. This would result in unpredictable behavior.
-
-These are all limitations of our deliberately naive caching mechanism, 
-and would not occur should the APIs use a shared database such as 
-MySQL or PostgreSQL.
+There is a noteworthy configuration difference when deploying the 
+OMS to Kubernetes. As detailed in the 
+[technical description](../technical-description.md#application-cache), 
+the OMS application's API servers maintain a cache of all orders 
+and shipments. By default, this is backed by a file-based SQLite 
+database. While this choice of database inherently limits scalability 
+to a single node, we felt that adding a dependency on an external 
+database created an obstacle for developers who want to get the 
+OMS running with minimal effort. We have since updated the OMS to 
+add the option to use MongoDB for the application cache. Not only
+does this represent a more typical production deployment, given
+MongoDB's reputation for scalability, it also avoids the complexity 
+of using Statefulsets for the API servers. For those reasons, we 
+default to MongoDB for the API servers' cache when deploying the 
+OMS to Kubernetes. 
 
 ## Using the Application
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I updated the k8s docs to remove the outdated info about SQLite in the k8s deployment and to briefly explain the use of MongoDB as the default in a k8s deployment.

## Why?
<!-- Tell your future self why have you made these changes -->
The information was no longer accurate or relevant as per the changes on the `rh-mongodb` branch.


## Checklist
1. Any docs updates needed?

Yes, I still need to update the [application cache section](https://github.com/temporalio/reference-app-orders-go/blob/main/docs/technical-description.md#application-cache) of the technical description page to describe the use of MongoDB and how to configure it in a local deployment. However, since that page has links to parts of the code that will change as a result of what's in the `rh-mongodb` branch, that is better done following the merge. 
