### PR TITLE
Rely on the workflow to notify API layer of order.

### DIFF
--- a/app/db/db.go
+++ b/app/db/db.go
@@ -112,9 +112,14 @@ func (m *MongoDB) Setup() error {
 	return nil
 }
 
-// InsertOrder inserts an Order into the MongoDB instance
+// InsertOrder inserts an Order into the MongoDB instance (with upsert semantics for idempotency)
 func (m *MongoDB) InsertOrder(ctx context.Context, order *OrderStatus) error {
-	_, err := m.db.Collection(OrdersCollection).InsertOne(ctx, order)
+	_, err := m.db.Collection(OrdersCollection).UpdateOne(
+		ctx,
+		bson.M{"id": order.ID},
+		bson.M{"$setOnInsert": order},
+		options.Update().SetUpsert(true),
+	)
 	return err
 }
 

--- a/app/order/activities.go
+++ b/app/order/activities.go
@@ -21,6 +21,34 @@ type Activities struct {
 
 var a Activities
 
+// InsertOrder inserts a new Order record into the database.
+func (a *Activities) InsertOrder(ctx context.Context, insert *OrderStatusInsert) error {
+	jsonInput, err := json.Marshal(insert)
+	if err != nil {
+		return fmt.Errorf("unable to encode insert: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.OrderURL+"/orders/"+insert.ID+"/insert", bytes.NewReader(jsonInput))
+	if err != nil {
+		return fmt.Errorf("unable to build request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("%s: %s", http.StatusText(res.StatusCode), body)
+	}
+
+	return nil
+}
+
 // UpdateOrderStatus stores the Order status to the database.
 func (a *Activities) UpdateOrderStatus(ctx context.Context, status *OrderStatusUpdate) error {
 	jsonInput, err := json.Marshal(status)

--- a/app/order/workflows_test.go
+++ b/app/order/workflows_test.go
@@ -19,6 +19,9 @@ func TestOrderWorkflow(t *testing.T) {
 	var a *order.Activities
 
 	env.RegisterActivity(a.ReserveItems)
+	env.OnActivity(a.InsertOrder, mock.Anything, mock.Anything).Return(func(ctx context.Context, input *order.OrderStatusInsert) error {
+		return nil
+	})
 	env.OnActivity(a.Charge, mock.Anything, mock.Anything).Return(func(ctx context.Context, input *order.ChargeInput) (*order.ChargeResult, error) {
 		return &order.ChargeResult{Success: true}, nil
 	})
@@ -56,6 +59,9 @@ func TestOrderShipmentStatus(t *testing.T) {
 	var a *order.Activities
 
 	env.RegisterActivity(a.ReserveItems)
+	env.OnActivity(a.InsertOrder, mock.Anything, mock.Anything).Return(func(ctx context.Context, input *order.OrderStatusInsert) error {
+		return nil
+	})
 	env.OnActivity(a.Charge, mock.Anything, mock.Anything).Return(func(ctx context.Context, input *order.ChargeInput) (*order.ChargeResult, error) {
 		return &order.ChargeResult{Success: true}, nil
 	})
@@ -109,6 +115,9 @@ func TestOrderAmendWithUnavailableItems(t *testing.T) {
 	var a *order.Activities
 
 	env.RegisterActivity(a.ReserveItems)
+	env.OnActivity(a.InsertOrder, mock.Anything, mock.Anything).Return(func(ctx context.Context, input *order.OrderStatusInsert) error {
+		return nil
+	})
 	env.OnActivity(a.Charge, mock.Anything, mock.Anything).Return(func(ctx context.Context, input *order.ChargeInput) (*order.ChargeResult, error) {
 		return &order.ChargeResult{Success: true}, nil
 	})
@@ -134,28 +143,21 @@ func TestOrderAmendWithUnavailableItems(t *testing.T) {
 		assert.NoError(t, err)
 
 		err = v.Get(&status)
-		assert.Equal(t, order.OrderStatus{
-			ID:         "1234",
-			CustomerID: "1234",
-			Status:     order.OrderStatusCustomerActionRequired,
-			Fulfillments: []*order.Fulfillment{
-				{
-					ID:     "1234:1",
-					Status: order.FulfillmentStatusUnavailable,
-					Items: []*order.Item{
-						{SKU: "Adidas", Quantity: 1},
-					},
-				},
-				{
-					ID:       "1234:2",
-					Status:   order.FulfillmentStatusPending,
-					Location: "Warehouse A",
-					Items: []*order.Item{
-						{SKU: "test2", Quantity: 3},
-					},
-				},
-			},
-		}, status)
+		assert.NoError(t, err)
+		assert.Equal(t, "1234", status.ID)
+		assert.Equal(t, "1234", status.CustomerID)
+		assert.Equal(t, order.OrderStatusCustomerActionRequired, status.Status)
+		assert.NotZero(t, status.ReceivedAt)
+		assert.Len(t, status.Fulfillments, 2)
+
+		assert.Equal(t, "1234:1", status.Fulfillments[0].ID)
+		assert.Equal(t, order.FulfillmentStatusUnavailable, status.Fulfillments[0].Status)
+		assert.Equal(t, []*order.Item{{SKU: "Adidas", Quantity: 1}}, status.Fulfillments[0].Items)
+
+		assert.Equal(t, "1234:2", status.Fulfillments[1].ID)
+		assert.Equal(t, order.FulfillmentStatusPending, status.Fulfillments[1].Status)
+		assert.Equal(t, "Warehouse A", status.Fulfillments[1].Location)
+		assert.Equal(t, []*order.Item{{SKU: "test2", Quantity: 3}}, status.Fulfillments[1].Items)
 	}, time.Second*1)
 
 	env.RegisterDelayedCallback(func() {
@@ -200,6 +202,9 @@ func TestOrderCancelWithUnavailableItems(t *testing.T) {
 	var a *order.Activities
 
 	env.RegisterActivity(a.ReserveItems)
+	env.OnActivity(a.InsertOrder, mock.Anything, mock.Anything).Return(func(ctx context.Context, input *order.OrderStatusInsert) error {
+		return nil
+	})
 	env.OnActivity(a.UpdateOrderStatus, mock.Anything, mock.Anything).Return(func(ctx context.Context, input *order.OrderStatusUpdate) error {
 		return nil
 	})
@@ -238,6 +243,9 @@ func TestOrderCancelAfterTimeout(t *testing.T) {
 	var a *order.Activities
 
 	env.RegisterActivity(a.ReserveItems)
+	env.OnActivity(a.InsertOrder, mock.Anything, mock.Anything).Return(func(ctx context.Context, input *order.OrderStatusInsert) error {
+		return nil
+	})
 	env.OnActivity(a.UpdateOrderStatus, mock.Anything, mock.Anything).Return(func(ctx context.Context, input *order.OrderStatusUpdate) error {
 		return nil
 	})


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Rely on the workflow to notify API layer of order.
<!-- Describe what has changed in this PR -->

## Why?
This avoids Temporal and DB being out of sync.

Orders that have been started but not begun executing yet will not appear on the order listing page. This seems like an acceptable trade-off for correctness, given they are considered "pending" anyway.

<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes #98 

2. How was this tested: unit tests and locally using docker-compose with mongodb
<!--- Please describe how you tested your changes/how we can test them -->

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
