### PR TITLE
Validate carrier-supplied status before applying it to a shipment

### DIFF
--- a/app/shipment/workflows.go
+++ b/app/shipment/workflows.go
@@ -136,10 +136,28 @@ func (s *shipmentImpl) handleCarrierUpdates(ctx workflow.Context) error {
 
 		s.logger.Info("Received carrier update", "status", signal.Status)
 
+		if !validCarrierStatus(signal.Status) {
+			s.logger.Warn("Ignoring carrier update with unknown status", "status", signal.Status)
+			continue
+		}
+
 		s.updateStatus(ctx, signal.Status)
 	}
 
 	return nil
+}
+
+// validCarrierStatus reports whether a carrier-supplied status is one of the
+// statuses a carrier may set. Carrier updates arrive over a signal from an
+// external party, so the value is validated before being applied — otherwise
+// any string the carrier sends would become the shipment's status (and be
+// propagated to the requesting Order workflow).
+func validCarrierStatus(status string) bool {
+	switch status {
+	case ShipmentStatusBooked, ShipmentStatusDispatched, ShipmentStatusDelivered:
+		return true
+	}
+	return false
 }
 
 func (s *shipmentImpl) updateStatus(ctx workflow.Context, status string) error {

--- a/app/shipment/workflows_test.go
+++ b/app/shipment/workflows_test.go
@@ -77,3 +77,74 @@ func TestShipmentWorkflow(t *testing.T) {
 	err := env.GetWorkflowResult(&result)
 	assert.NoError(t, err)
 }
+
+func TestShipmentWorkflowIgnoresUnknownCarrierStatus(t *testing.T) {
+	s := testsuite.WorkflowTestSuite{}
+	env := s.NewTestWorkflowEnvironment()
+	a := &shipment.Activities{}
+
+	shipmentInput := shipment.ShipmentInput{
+		RequestorWID: "parentwid",
+		ID:           "test",
+		Items: []shipment.Item{
+			{SKU: "test1", Quantity: 1},
+		},
+	}
+
+	env.RegisterActivity(a.BookShipment)
+
+	// A carrier update with a status outside the known set must be ignored:
+	// it must neither become the shipment's status nor be forwarded to the
+	// requestor.
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(
+			shipment.ShipmentCarrierUpdateSignalName,
+			shipment.ShipmentCarrierUpdateSignal{
+				Status: "lost-in-transit",
+			},
+		)
+	}, time.Second*1)
+
+	env.RegisterDelayedCallback(func() {
+		v, err := env.QueryWorkflow(shipment.StatusQuery)
+		assert.NoError(t, err)
+		var status shipment.ShipmentStatus
+		assert.NoError(t, v.Get(&status))
+		assert.Equal(t, shipment.ShipmentStatusBooked, status.Status)
+	}, time.Second*2)
+
+	env.RegisterDelayedCallback(func() {
+		env.SignalWorkflow(
+			shipment.ShipmentCarrierUpdateSignalName,
+			shipment.ShipmentCarrierUpdateSignal{
+				Status: shipment.ShipmentStatusDelivered,
+			},
+		)
+	}, time.Second*3)
+
+	env.OnSignalExternalWorkflow(mock.Anything,
+		"parentwid", "",
+		shipment.ShipmentStatusUpdatedSignalName,
+		mock.MatchedBy(func(arg shipment.ShipmentStatusUpdatedSignal) bool {
+			return arg.Status == shipment.ShipmentStatusBooked
+		}),
+	).Return(nil).Once()
+
+	env.OnSignalExternalWorkflow(mock.Anything,
+		"parentwid", "",
+		shipment.ShipmentStatusUpdatedSignalName,
+		mock.MatchedBy(func(arg shipment.ShipmentStatusUpdatedSignal) bool {
+			return arg.Status == shipment.ShipmentStatusDelivered
+		}),
+	).Return(nil).Once()
+
+	env.ExecuteWorkflow(
+		shipment.Shipment,
+		&shipmentInput,
+	)
+
+	var result shipment.ShipmentResult
+	err := env.GetWorkflowResult(&result)
+	assert.NoError(t, err)
+	env.AssertExpectations(t)
+}


### PR DESCRIPTION
## What

The Shipment workflow's carrier-update loop applies `signal.Status` to the shipment verbatim:

```go
for s.status != ShipmentStatusDelivered {
    ch.Receive(ctx, &signal)
    s.updateStatus(ctx, signal.Status)
}
```

Since the signal comes from an external party, any string a carrier sends becomes the shipment's observable status — outside the documented `pending/booked/dispatched/delivered` set — and is forwarded to the requesting Order workflow, which stores it verbatim as well.

This PR validates the carrier-supplied status against the known carrier-settable set (`booked`, `dispatched`, `delivered`) and logs-and-ignores anything else. Known statuses behave exactly as before. A test asserts that an unknown status neither changes the shipment's status nor notifies the requestor.

## How this was found

I ran a formal-verification exercise over this reference app's Order and Shipment workflows: traces captured from the unmodified workflows via the SDK's `testsuite`, several independently LLM-derived specs replayed against those traces, then an exhaustive model check against intent invariants. The counterexample for this one is two steps from init (`BOOKED → CARRIER_UPDATE("lost-in-transit")`). Full write-up, traces, and counterexamples: https://github.com/jdubray/polygraph/tree/main/examples/polygraph-oms-go

Two related observations from the same exercise that I deliberately did **not** change, since they read as intentional demo simplifications rather than oversights — flagging them here in case they're worth an issue:

- A carrier can also move status *backwards* (`dispatched → booked`, even back to `pending`) — this PR keeps that behavior for the known statuses, since a carrier "correction" may be intended.
- On the Order side, an order whose fulfillments are all cancelled (every item unavailable → customer amends) completes with status `completed`, and a partial failure (one fulfillment failed, one delivered) also reports `completed` — `allFulfillmentsFailed()` counts only `failed`.

Happy to adjust scope or drop this entirely if the verbatim behavior is intentional for the demo — treating maintainers' read of intent as authoritative here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpdSdufYcKnkvzhB56NkVn